### PR TITLE
Better integration with resources

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "assets/submodules/resources"]
+	path = assets/submodules/resources
+	url = git@github.com:HackQuarantine/resources.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "assets/submodules/resources"]
-	path = assets/submodules/resources
+	path = _data/resources
 	url = git@github.com:HackQuarantine/resources.git

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -13,10 +13,10 @@
         <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.4.1/css/bootstrap.min.css" integrity="sha384-Vkoo8x4CGsO3+Hhxv8T/Q5PaXtkKtu6ug5TOeNV6gBiFeWPGFN9MuhOf23Q9Ifjh" crossorigin="anonymous">
         <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.12.1/css/all.min.css" integrity="sha256-mmgLkCYLUQbXn0B1SRqzHar6dCnv9oZFPEC1g1cwlkk=" crossorigin="anonymous" />
         <link href="https://fonts.googleapis.com/css?family=Source+Code+Pro:400,600,700i&display=swap" rel="stylesheet">
-        <link rel="stylesheet" href="./assets/css/nav-bar.css">
-        <link rel="stylesheet" href="./assets/css/style.css">
+        <link rel="stylesheet" href="/assets/css/nav-bar.css">
+        <link rel="stylesheet" href="/assets/css/style.css">
 
-        <script src="./assets/js/nav-bar.js"></script>
+        <script src="/assets/js/nav-bar.js"></script>
 
         <!-- external scripts -->
         {% if page.scripts %}

--- a/resources.md
+++ b/resources.md
@@ -1,0 +1,1 @@
+_data/resources/resources.md


### PR DESCRIPTION
Make the resources repo a sub-module in this repo. This means the nav-bar now has a "Resources" link.

![image](https://user-images.githubusercontent.com/34094978/76907294-c572a300-689d-11ea-96f4-f7d92e391a8a.png)


The resources repo is now also a single file "resources.md" instead of a whole jekyll site.