### PR TITLE
Fix /upcoming page

### DIFF
--- a/assets/js/upcoming.js
+++ b/assets/js/upcoming.js
@@ -45,7 +45,7 @@ document.addEventListener('DOMContentLoaded', () => {
     },
     eventClick: (info) => {
       info.jsEvent.preventDefault()
-      parent.window.location.href = '/schedule'
+      parent.window.location.href = 'https://hackquarantine.com/schedule'
     },
     eventRender: (info) => {
       try {
@@ -60,7 +60,7 @@ document.addEventListener('DOMContentLoaded', () => {
   setVisibleRange()
   calendar.render()
 
-  setTimeout(setVisibleRange, RANGE_UPDATE_INTERVAL * 1000)
+  setInterval(setVisibleRange, RANGE_UPDATE_INTERVAL * 1000)
 })
 
 function setVisibleRange () {


### PR DESCRIPTION
- Interval timer now fires every 1 min instead of only once
- Clicking an event links to https://hackquarantine.com/schedule instead of /schedule in case people embed the page in a strange way