### PR TITLE
Use non-monospace font for paragraphs on resources/workshops

### DIFF
--- a/assets/css/resources.css
+++ b/assets/css/resources.css
@@ -1,3 +1,7 @@
 body {
     background-color: #0e1428;
 }
+
+p {
+  font-family: unset;
+}


### PR DESCRIPTION
(improves text readability & consistency as the lists are already non-monospace)
Before:
![image](https://user-images.githubusercontent.com/34094978/77313607-15b58f00-6cfc-11ea-87b3-18d3f50653be.png)

After:
![Screenshot_2020-03-23 Workshop Host Info](https://user-images.githubusercontent.com/34094978/77313632-1cdc9d00-6cfc-11ea-9827-1bce1d0dff9e.png)
