### PR TITLE
Only play livestream when it is visible

### DIFF
--- a/_includes/hero.html
+++ b/_includes/hero.html
@@ -50,7 +50,7 @@
 
             <div href="#" id="embedded-content">
                 <iframe id="embedded-schedule" scrolling="no" title="HackQuarantine Upcoming Events" src="/upcoming"></iframe>
-                <iframe id="embedded-iframe" title="HackQuarantine Livestream" src="https://player.twitch.tv/?channel=hackquarantine&muted=1"></iframe>
+                <iframe id="embedded-iframe" title="HackQuarantine Livestream"></iframe>
                 <!-- <iframe id="embedded-iframe" title="HackQuarantine Livestream" src="https://mixer.com/embed/player/HackQuarantine?disableLowLatency=1?muted=1"> </iframe> -->
             </div>
         </div>

--- a/assets/js/embed.js
+++ b/assets/js/embed.js
@@ -67,6 +67,7 @@ function setEmbedVisibility (show) {
 
 function showStream () {
   stream = true
+  $('#embedded-iframe').attr('src', 'https://player.twitch.tv/?channel=hackquarantine&muted=1')
   $('#embedded-iframe').css('display', 'block')
   $('#embedded-schedule').css('display', 'none')
   resizeIframes()
@@ -74,6 +75,7 @@ function showStream () {
 
 function showSchedule () {
   stream = false
+  $('#embedded-iframe').removeAttr('src')
   $('#embedded-iframe').css('display', 'none')
   $('#embedded-schedule').css('display', 'block')
   resizeIframes()


### PR DESCRIPTION
This is to avoid people's data plans getting used up when just the 
calendar is displayed