### PR TITLE
Changes to /upcoming page

### DIFF
--- a/assets/js/upcoming.js
+++ b/assets/js/upcoming.js
@@ -54,6 +54,11 @@ document.addEventListener('DOMContentLoaded', () => {
       } catch (e) {
         console.error('cannot parse event details/ find colour')
       }
+
+      if (info.event._instance.range.end < new Date()) {
+        // if the event is today but has finished, don't show it
+        return false
+      }
     }
   })
 


### PR DESCRIPTION
Don't show events that have ended (even if they are on the same day)

Not convinced that this actually works yet, so don't merge.