### PR TITLE
Fix /upcoming schedule for non GMT timezones

### DIFF
--- a/assets/js/upcoming.js
+++ b/assets/js/upcoming.js
@@ -55,7 +55,10 @@ document.addEventListener('DOMContentLoaded', () => {
         console.error('cannot parse event details/ find colour')
       }
 
-      if (info.event._instance.range.end < new Date()) {
+      const endTime = info.event._instance.range.end
+      const endUnix = endTime.getTime() + (1000 * 60 * endTime.getTimezoneOffset())
+      const nowUnix = (new Date()).getTime()
+      if (endUnix < nowUnix) {
         // if the event is today but has finished, don't show it
         return false
       }

--- a/assets/js/upcoming.js
+++ b/assets/js/upcoming.js
@@ -3,7 +3,7 @@
 const CALENDAR_ID = 'hacksocnotts.co.uk_5m2l3o30k13frs9nd9dmh9rk8o@group.calendar.google.com'
 const CALENDAR_KEY = 'AIzaSyBzgsuQnfQ7g_zMSsmll7XosF5ZxpJZaWk'
 
-const END_DATE = '2020-04-12'
+const END_DATE = '2020-04-13'
 const RANGE_UPDATE_INTERVAL = 60 // sec
 
 const DATE_24HR_FORMAT = {


### PR DESCRIPTION
Fullcalendar.js was returning incorrect times, but correct time zone info. Use the time zone info to fix the times before comparing them to the present. This means the embedded calendar should not hide events that haven't happened yet.