### PR TITLE
Add year to homepage

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -3,7 +3,7 @@ defaults:
     values:
       title: Hack Quarantine
       tagline: A global, virtual hackathon
-      daterange: March 23rd to April 12th
+      daterange: March 23, 2020 to April 12, 2020
       assets:
         small_logo: './assets/img/small_logo.png'
         logo: './assets/img/logo.png'


### PR DESCRIPTION
Since 'March 23rd to April 12th' isn't clear long-term, adding the year.

Ultimately we'll need to think about the existence of this website long-term anyway, but this is at least a medium-term fix.